### PR TITLE
use return Keyword / arrow Function

### DIFF
--- a/lib/services/database.dart
+++ b/lib/services/database.dart
@@ -60,10 +60,8 @@ class NotesDatabaseService {
   Future<NotesModel> addNoteInDB(NotesModel newNote) async {
     final db = await database;
     if (newNote.title.trim().isEmpty) newNote.title = 'Untitled Note';
-    int id = await db.transaction((transaction) {
-      transaction.rawInsert(
-          'INSERT into Notes(title, content, date, isImportant) VALUES ("${newNote.title}", "${newNote.content}", "${newNote.date.toIso8601String()}", ${newNote.isImportant == true ? 1 : 0});');
-    });
+   int id = await db.transaction((transaction) => transaction.rawInsert(
+        'INSERT into Notes(title, content, date, isImportant) VALUES ("${newNote.title}", "${newNote.content}", "${newNote.date.toIso8601String()}", ${newNote.isImportant == true ? 1 : 0});'));
     newNote.id = id;
     print('Note added: ${newNote.title} ${newNote.content}');
     return newNote;


### PR DESCRIPTION
# info: This function has a return type of 'Future<int>', but doesn't end with a return statement. (missing_return at [notes] lib/services/database.dart).

Beacuse transaction.rawInsert() Not use Return Keyword / arrow function so id always store null.